### PR TITLE
Add the possibility to use the rootNavigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ AwesomeDialog has onDissmissCallback() and can be dissmissed at any time using d
 |onDissmissCallback            | Function      | Dissmiss callback funtion    | Null |
 | animType             | AnimType      | Type of dialogue enter animation                                 | AnimType.SCALE |
 | aligment             | AlignmentGeometry      | dialogue aligment gravity                                | Alignment.center |
-
+| useRootNavigator     | bool    | Use the root navigator insteed than the local. This is usefuk when the defaut cancel go to the previous screen insteed to just close the dialog | false |
 
 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ AwesomeDialog has onDissmissCallback() and can be dissmissed at any time using d
 |onDissmissCallback            | Function      | Dissmiss callback funtion    | Null |
 | animType             | AnimType      | Type of dialogue enter animation                                 | AnimType.SCALE |
 | aligment             | AlignmentGeometry      | dialogue aligment gravity                                | Alignment.center |
-| useRootNavigator     | bool    | Use the root navigator insteed than the local. This is usefuk when the defaut cancel go to the previous screen insteed to just close the dialog | false |
+| useRootNavigator     | bool    | Use the root navigator instead than the local. This is usefuk when the defaut cancel go to the previous screen instead to just close the dialog | false |
 
 
 

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -31,6 +31,7 @@ class AwesomeDialog {
   final AnimType animType;
   final AlignmentGeometry aligment;
   final bool isDense;
+  final bool useRootNavigator;
   AwesomeDialog(
       {@required this.context,
       this.dialogType,
@@ -52,7 +53,8 @@ class AwesomeDialog {
       this.isDense = false,
       this.dismissOnTouchOutside = true,
       this.aligment = Alignment.center,
-      this.animType = AnimType.SCALE})
+      this.animType = AnimType.SCALE,
+      this.useRootNavigator = false})
       : assert(
           (dialogType != null || customHeader != null),
           context != null,
@@ -110,7 +112,7 @@ class AwesomeDialog {
   _buildFancyButtonOk() {
     return AnimatedButton(
       pressEvent: () {
-        Navigator.of(context).pop();
+        Navigator.of(context, rootNavigator: useRootNavigator).pop();
         btnOkOnPress();
       },
       text: btnOkText ?? 'Ok',
@@ -122,7 +124,7 @@ class AwesomeDialog {
   _buildFancyButtonCancel() {
     return AnimatedButton(
       pressEvent: () {
-        Navigator.of(context).pop();
+        Navigator.of(context, rootNavigator: useRootNavigator).pop();
         btnCancelOnPress();
       },
       text: btnCancelText ?? 'Cancel',
@@ -132,6 +134,6 @@ class AwesomeDialog {
   }
 
   dissmiss() {
-    Navigator.of(context).pop();
+    Navigator.of(context, rootNavigator: useRootNavigator).pop();
   }
 }


### PR DESCRIPTION
Dependant of your app and your navigator architecture, when you use
```dart
Navigator.of(context).pop();
```
You will redirect to the previous screen instead to close the dialog.  We have to use the root navigator to fix this issue and close the dialog.

