### PR TITLE
Enable Close Icon on awesomeDialog

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Fancy Dialog Example',
+      theme: ThemeData.dark(),
       initialRoute: '/',
       onGenerateRoute: RouteGenerator.generateRoute,
     );
@@ -49,6 +50,7 @@ class _HomePageState extends State<HomePage> {
                       animType: AnimType.BOTTOMSLIDE,
                       title: 'INFO',
                       desc: 'Dialog description here...',
+                      showCloseIcon: true,
                       btnCancelOnPress: () {},
                       btnOkOnPress: () {},
                     )..show();
@@ -82,6 +84,8 @@ class _HomePageState extends State<HomePage> {
                         dialogType: DialogType.WARNING,
                         headerAnimationLoop: false,
                         animType: AnimType.TOPSLIDE,
+                        showCloseIcon: true,
+                        closeIcon: Icon(Icons.close_fullscreen_outlined),
                         title: 'Warning',
                         desc:
                             'Dialog description here..................................................',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   awesome_dialog:
     dependency: "direct main"
     description:
@@ -21,35 +21,35 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   flare_dart:
     dependency: transitive
     description:
@@ -94,21 +94,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   sa_anicoto:
     dependency: transitive
     description:
@@ -155,28 +155,28 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   supercharged:
     dependency: transitive
     description:
@@ -197,27 +197,27 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -83,14 +83,17 @@ class AwesomeDialog {
   ///Control if Dialog is dissmis by back key.
   final bool dismissOnBackKeyPress;
 
-  ///Max with of entire Dialog
+  ///Max with of entire Dialog.
   final double width;
 
-  ///Max with of entire Dialog
+  ///Border Radius for built in buttons.
   final BorderRadiusGeometry buttonsBorderRadius;
-  
+
   /// Control if close icon is appear.
   final bool showCloseIcon;
+
+  /// Custom closeIcon.
+  final Widget closeIcon;
 
   AwesomeDialog({
     @required this.context,
@@ -123,6 +126,7 @@ class AwesomeDialog {
     this.width,
     this.buttonsBorderRadius,
     this.showCloseIcon = false,
+    this.closeIcon,
   }) : assert(
           context != null,
         );
@@ -186,9 +190,10 @@ class AwesomeDialog {
           width: width,
           padding: padding ?? EdgeInsets.only(left: 5, right: 5),
           btnOk: btnOk ?? (btnOkOnPress != null ? _buildFancyButtonOk : null),
-          btnCancel: btnCancel ??
-              (btnCancelOnPress != null ? _buildFancyButtonCancel : null),
+          btnCancel: btnCancel ?? (btnCancelOnPress != null ? _buildFancyButtonCancel : null),
           showCloseIcon: this.showCloseIcon,
+          onClose: dissmiss,
+          closeIcon: closeIcon,
         ),
       );
 
@@ -217,8 +222,7 @@ class AwesomeDialog {
       );
 
   dissmiss() {
-    if (!isDissmisedBySystem)
-      Navigator.of(context, rootNavigator: useRootNavigator)?.pop();
+    if (!isDissmisedBySystem) Navigator.of(context, rootNavigator: useRootNavigator)?.pop();
   }
 
   Future<bool> _onWillPop() async => dismissOnBackKeyPress;

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -88,6 +88,9 @@ class AwesomeDialog {
 
   ///Max with of entire Dialog
   final BorderRadiusGeometry buttonsBorderRadius;
+  
+  /// Control if close icon is appear.
+  final bool showCloseIcon;
 
   AwesomeDialog({
     @required this.context,
@@ -119,6 +122,7 @@ class AwesomeDialog {
     this.dismissOnBackKeyPress = true,
     this.width,
     this.buttonsBorderRadius,
+    this.showCloseIcon = false,
   }) : assert(
           context != null,
         );
@@ -184,6 +188,7 @@ class AwesomeDialog {
           btnOk: btnOk ?? (btnOkOnPress != null ? _buildFancyButtonOk : null),
           btnCancel: btnCancel ??
               (btnCancelOnPress != null ? _buildFancyButtonCancel : null),
+          showCloseIcon: this.showCloseIcon,
         ),
       );
 

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -26,6 +26,7 @@ class VerticalStackDialog extends StatelessWidget {
     this.padding,
     this.keyboardAware,
     this.width,
+    this.showCloseIcon,
   }) : super(key: key);
 
   @override

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -13,6 +13,8 @@ class VerticalStackDialog extends StatelessWidget {
   final bool keyboardAware;
   final double width;
   final bool showCloseIcon;
+  final Function onClose;
+  final Widget closeIcon;
   const VerticalStackDialog({
     Key key,
     @required this.title,
@@ -27,26 +29,25 @@ class VerticalStackDialog extends StatelessWidget {
     this.keyboardAware,
     this.width,
     this.showCloseIcon,
+    @required this.onClose,
+    this.closeIcon,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
       alignment: aligment,
-      padding: EdgeInsets.only(
-          bottom: keyboardAware ? MediaQuery.of(context).viewInsets.bottom : 0),
+      padding:
+          EdgeInsets.only(bottom: keyboardAware ? MediaQuery.of(context).viewInsets.bottom : 0),
       child: Stack(
         children: <Widget>[
           Container(
             width: width ?? MediaQuery.of(context).size.width,
             padding: isDense
-                ? const EdgeInsets.only(
-                    top: 65.0, left: 15.0, right: 15.0, bottom: 10.0)
-                : const EdgeInsets.only(
-                    top: 65.0, left: 40.0, right: 40.0, bottom: 10.0),
+                ? const EdgeInsets.only(top: 65.0, left: 15.0, right: 15.0, bottom: 10.0)
+                : const EdgeInsets.only(top: 65.0, left: 40.0, right: 40.0, bottom: 10.0),
             child: Material(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0)),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10.0)),
               elevation: 0.5,
               color: Theme.of(context).cardColor,
               child: Padding(
@@ -88,8 +89,7 @@ class VerticalStackDialog extends StatelessWidget {
                       ),
                       if (btnOk != null || btnCancel != null)
                         Container(
-                          padding: EdgeInsets.symmetric(
-                              vertical: 10, horizontal: 20),
+                          padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
@@ -130,21 +130,13 @@ class VerticalStackDialog extends StatelessWidget {
             ),
           if (showCloseIcon)
             Positioned(
-              right: 45.0,
-              top: 70.0,
+              right: 50.0,
+              top: 75.0,
               child: GestureDetector(
                 onTap: () {
-                  Navigator.of(context).pop();
+                  onClose?.call();
                 },
-                child: Align(
-                  alignment: Alignment.topRight,
-                  child: Icon(Icons.close, color: Colors.red),
-                  // child: CircleAvatar(
-                  //   radius: 14.0,
-                  //   backgroundColor: Colors.white,
-                  //   child: Icon(Icons.close, color: Colors.red),
-                  // ),
-                ),
+                child: closeIcon ?? Icon(Icons.close),
               ),
             ),
         ],

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -130,19 +130,20 @@ class VerticalStackDialog extends StatelessWidget {
             ),
           if (showCloseIcon)
             Positioned(
-              right: 40.0,
-              top: 0.0,
+              right: 45.0,
+              top: 70.0,
               child: GestureDetector(
                 onTap: () {
                   Navigator.of(context).pop();
                 },
                 child: Align(
                   alignment: Alignment.topRight,
-                  child: CircleAvatar(
-                    radius: 14.0,
-                    backgroundColor: Colors.white,
-                    child: Icon(Icons.close, color: Colors.red),
-                  ),
+                  child: Icon(Icons.close, color: Colors.red),
+                  // child: CircleAvatar(
+                  //   radius: 14.0,
+                  //   backgroundColor: Colors.white,
+                  //   child: Icon(Icons.close, color: Colors.red),
+                  // ),
                 ),
               ),
             ),

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -12,6 +12,7 @@ class VerticalStackDialog extends StatelessWidget {
   final EdgeInsetsGeometry padding;
   final bool keyboardAware;
   final double width;
+  final bool showCloseIcon;
   const VerticalStackDialog({
     Key key,
     @required this.title,
@@ -126,6 +127,7 @@ class VerticalStackDialog extends StatelessWidget {
                 ],
               ),
             ),
+          if (showCloseIcon)
           Positioned(
             right: 40.0,
             top: 0.0,

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -126,6 +126,23 @@ class VerticalStackDialog extends StatelessWidget {
                 ],
               ),
             ),
+          Positioned(
+            right: 40.0,
+            top: 0.0,
+            child: GestureDetector(
+              onTap: () {
+                Navigator.of(context).pop();
+              },
+              child: Align(
+                alignment: Alignment.topRight,
+                child: CircleAvatar(
+                  radius: 14.0,
+                  backgroundColor: Colors.white,
+                  child: Icon(Icons.close, color: Colors.red),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -128,23 +128,23 @@ class VerticalStackDialog extends StatelessWidget {
               ),
             ),
           if (showCloseIcon)
-          Positioned(
-            right: 40.0,
-            top: 0.0,
-            child: GestureDetector(
-              onTap: () {
-                Navigator.of(context).pop();
-              },
-              child: Align(
-                alignment: Alignment.topRight,
-                child: CircleAvatar(
-                  radius: 14.0,
-                  backgroundColor: Colors.white,
-                  child: Icon(Icons.close, color: Colors.red),
+            Positioned(
+              right: 40.0,
+              top: 0.0,
+              child: GestureDetector(
+                onTap: () {
+                  Navigator.of(context).pop();
+                },
+                child: Align(
+                  alignment: Alignment.topRight,
+                  child: CircleAvatar(
+                    radius: 14.0,
+                    backgroundColor: Colors.white,
+                    child: Icon(Icons.close, color: Colors.red),
+                  ),
                 ),
               ),
             ),
-          ),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   flare_dart:
     dependency: transitive
     description:
@@ -80,21 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   sa_anicoto:
     dependency: transitive
     description:
@@ -141,28 +141,28 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   supercharged:
     dependency: transitive
     description:
@@ -176,27 +176,27 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"


### PR DESCRIPTION
A new key, showCloseIcon (by default false, i.e hide close icon).

If showCloseIcon set to true, close icon will show when awesomeDialog prompt. Dialog will be dismiss if close icon trigger.

Close icon is used in order to eliminate the crowd in buttons panel & developer can make use the limited buttons for other purposes, rather than just to close the dialog. 