### PR TITLE
`onDissmissCallback` not executed for custom button pop

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion flutter.compileSdkVersion
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "cu.marcos930807.fancy_dialog_example"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="fancy_dialog_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         jcenter()

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -286,6 +286,8 @@ class AwesomeDialog {
         buttonTextStyle: buttonsTextStyle,
       );
 
+  /// Called to dismiss the dialog using the [Navigator.pop] method
+  /// or calls the [onDissmissCallback] function if [autoDismiss] is `false`
   void dismiss() {
     if (autoDismiss) {
       Navigator.of(context, rootNavigator: useRootNavigator).pop();

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -155,6 +155,10 @@ class AwesomeDialog {
 
   DismissType _dismissType = DismissType.OTHER;
 
+  /// Used to call the `onDissmissCallback` if dialog
+  /// is popped using custom [Navigator.pop] method.
+  bool _onDissmissCallbackCalled = false;
+
   Future show() => showDialog(
         context: context,
         useRootNavigator: useRootNavigator,
@@ -188,7 +192,11 @@ class AwesomeDialog {
               return _buildDialog;
           }
         },
-      );
+      )..then(
+          (value) => _onDissmissCallbackCalled
+              ? null
+              : onDissmissCallback?.call(_dismissType),
+        );
 
   Widget? get _buildHeader {
     if (customHeader != null) return customHeader;
@@ -258,6 +266,7 @@ class AwesomeDialog {
       Navigator.of(context, rootNavigator: useRootNavigator).pop();
     }
     onDissmissCallback?.call(_dismissType);
+    _onDissmissCallbackCalled = true;
   }
 
   Future<bool> _onWillPop() async {

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -33,16 +33,28 @@ class AwesomeDialog {
   /// Create your own Widget for body, if this property is set title and description will be ignored.
   final Widget? body;
 
-  /// Btn OK props
+  /// Text for the Ok button
   final String? btnOkText;
+
+  /// Icon to use for the Ok button
   final IconData? btnOkIcon;
+
+  /// Function to execute when Ok button is pressed
   final Function? btnOkOnPress;
+
+  /// Color of the Ok Button
   final Color? btnOkColor;
 
-  /// Btn Cancel props
+  /// Text for the Cancel button
   final String? btnCancelText;
+
+  /// Icon to use for the Cancel button
   final IconData? btnCancelIcon;
+
+  /// Function to execute when Cancel button is pressed
   final Function? btnCancelOnPress;
+
+  /// Color of the Cancel Button
   final Color? btnCancelColor;
 
   /// Custom Btn OK
@@ -108,9 +120,14 @@ class AwesomeDialog {
   /// Set BorderSide of DialogShape
   final BorderSide? borderSide;
 
-  /// Useful when you want to pass data from [Navigator.pop]
+  /// Set to `false` when you want to pass data from custom [Navigator.pop]
+  ///
+  /// Defaults to `true`
   final bool autoDismiss;
 
+  /// Creates a Dialog that is shown using the [showDialog] function
+  ///
+  /// Returns null if [autoDismiss] is true, else returns data passed to custom [Navigator.pop] function
   AwesomeDialog({
     required this.context,
     this.dialogType = DialogType.INFO,
@@ -153,12 +170,16 @@ class AwesomeDialog {
           "If autoDismiss is false, you must provide an onDissmissCallback to pop the dialog",
         );
 
+  /// The type for dismissal of the dialog
   DismissType _dismissType = DismissType.OTHER;
 
   /// Used to call the `onDissmissCallback` if dialog
   /// is popped using custom [Navigator.pop] method.
   bool _onDissmissCallbackCalled = false;
 
+  /// Shows the dialog using the [showDialog] function
+  ///
+  /// Returns `null` if [autoDismiss] is true, else returns data passed to custom [Navigator.pop] function
   Future show() => showDialog(
         context: context,
         useRootNavigator: useRootNavigator,
@@ -198,6 +219,7 @@ class AwesomeDialog {
               : onDissmissCallback?.call(_dismissType),
         );
 
+  /// Return the header of the dialog
   Widget? get _buildHeader {
     if (customHeader != null) return customHeader;
     if (dialogType == DialogType.NO_HEADER) return null;
@@ -207,6 +229,7 @@ class AwesomeDialog {
     );
   }
 
+  /// Returns the body of the dialog
   Widget get _buildDialog => WillPopScope(
         onWillPop: _onWillPop,
         child: VerticalStackDialog(
@@ -233,6 +256,7 @@ class AwesomeDialog {
         ),
       );
 
+  /// Returns the default `Ok Button` widget
   Widget get _buildFancyButtonOk => AnimatedButton(
         isFixedHeight: false,
         pressEvent: () {
@@ -247,6 +271,7 @@ class AwesomeDialog {
         buttonTextStyle: buttonsTextStyle,
       );
 
+  /// Returns the default `Cancel Button` widget
   Widget get _buildFancyButtonCancel => AnimatedButton(
         isFixedHeight: false,
         pressEvent: () {
@@ -269,6 +294,7 @@ class AwesomeDialog {
     _onDissmissCallbackCalled = true;
   }
 
+  /// Executes when `back button` pressed or `barrier dismissed`
   Future<bool> _onWillPop() async {
     if (dismissOnBackKeyPress) {
       _dismissType = DismissType.OTHER;

--- a/lib/src/animated_button.dart
+++ b/lib/src/animated_button.dart
@@ -1,14 +1,33 @@
 import 'package:flutter/material.dart';
 
 class AnimatedButton extends StatefulWidget {
+  /// Function to execute when button is pressed
   final Function pressEvent;
+
+  /// Text of the [AnimatedButton]
   final String? text;
+
+  /// Icon for the [AnimatedButton]
   final IconData? icon;
+
+  /// Width of the [AnimatedButton]
   final double width;
+
+  /// Height of the [AnimatedButton]
   final double? height;
+
+  /// If true, height is setted to `50.0`.
+  ///
+  /// Priority over [height]
   final bool isFixedHeight;
+
+  /// Color for the [AnimatedButton]
   final Color? color;
+
+  /// Border Radius of the [AnimatedButton]
   final BorderRadiusGeometry? borderRadius;
+
+  /// Textstyle to use for the text of the [AnimatedButton]
   final TextStyle? buttonTextStyle;
 
   const AnimatedButton({

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -164,6 +164,7 @@ class VerticalStackDialog extends StatelessWidget {
     );
   }
 
+  /// The default widget for the Title of dialog
   List<Widget> _titleBody(String title, ThemeData theme) => [
         Text(
           title,


### PR DESCRIPTION
### Fixes
- `onDissmissCallback` not executed when dialog popped using a custom *button/body*

### Docs
Added DartDoc comments for properties and methods of
  - AwesomeDialog
  - AnimatedButton

### Changes
- Configured android build setting to new flutter standards