### PR TITLE
Feature: Can manually set padding between body and dialog top for **no header**

### DIFF
--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -149,6 +149,12 @@ class AwesomeDialog {
   /// Defaults to `false`
   final bool enableEnterKey;
 
+  /// Sets **gap/distance** between the top of the body and header
+  /// when [dialogType] is [DialogType.NO_HEADER]
+  ///
+  /// Defaults to `15.0`
+  final double bodyHeaderDistance;
+
   /// Creates a Dialog that is shown using the [showDialog] function
   ///
   /// Returns null if [autoDismiss] is true, else returns data passed to custom [Navigator.pop] function
@@ -193,6 +199,7 @@ class AwesomeDialog {
     this.autoDismiss = true,
     this.barrierColor = Colors.black54,
     this.enableEnterKey = false,
+    this.bodyHeaderDistance = 15.0,
   }) : assert(
           autoDismiss || onDissmissCallback != null,
           "If autoDismiss is false, you must provide an onDissmissCallback to pop the dialog",
@@ -277,6 +284,7 @@ class AwesomeDialog {
             keyboardAware: keyboardAware,
             width: width,
             padding: padding ?? const EdgeInsets.only(left: 5, right: 5),
+            bodyHeaderDistance: bodyHeaderDistance,
             btnOk: btnOk ?? (btnOkOnPress != null ? _buildFancyButtonOk : null),
             btnCancel: btnCancel ?? (btnCancelOnPress != null ? _buildFancyButtonCancel : null),
             showCloseIcon: showCloseIcon,

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -20,6 +20,7 @@ class VerticalStackDialog extends StatelessWidget {
   final Color? dialogBackgroundColor;
   final BorderSide? borderSide;
   final BorderRadiusGeometry? borderRadius;
+  final double bodyHeaderDistance;
 
   const VerticalStackDialog({
     Key? key,
@@ -42,6 +43,7 @@ class VerticalStackDialog extends StatelessWidget {
     this.dialogBackgroundColor,
     this.borderSide,
     this.borderRadius,
+    this.bodyHeaderDistance = 15.0,
   }) : super(key: key);
 
   @override
@@ -79,7 +81,7 @@ class VerticalStackDialog extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
                       SizedBox(
-                        height: header != null ? 50.0 : 15,
+                        height: header != null ? 50.0 : bodyHeaderDistance,
                       ),
                       body ??
                           Column(


### PR DESCRIPTION
## New
- Added new property to define padding between **Dialog Body**  and **Dialog Top** when **Header** is set to **No Header**
- If not provided, defaults to `15.0`

resolves #89

P.S. If PR is accepted, please update the package version and upload it to `pub.dev`