### PR TITLE
Fix: Autohide pop unmounted widget

### DIFF
--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -231,7 +231,9 @@ class AwesomeDialog {
         barrierColor: barrierColor,
         builder: (BuildContext context) {
           if (autoHide != null) {
-            Future<void>.delayed(autoHide!).then((dynamic value) => dismiss());
+            Future<void>.delayed(autoHide!).then(
+              (dynamic value) => _onDissmissCallbackCalled ? null : dismiss(),
+            );
           }
           switch (animType) {
             case AnimType.SCALE:

--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -216,8 +216,9 @@ class AwesomeDialog {
   /// The type for dismissal of the dialog
   DismissType _dismissType = DismissType.OTHER;
 
-  /// Used to call the `onDissmissCallback` if dialog
-  /// is popped using custom [Navigator.pop] method.
+  /// Used to check if the [onDissmissCallback] is called. (also to see if dialog is popped)
+  ///
+  /// Initialized to `false`
   bool _onDissmissCallbackCalled = false;
 
   /// Shows the dialog using the [showDialog] function


### PR DESCRIPTION
## Fixes
- Docs for a property
- Autohide feature popping unmounted context

## Changes
- Added check to see if dialog is already popped i.e. check if unmounted

resolves #101