### PR TITLE
Removed unnecessary unrelated code in example file

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,6 @@
 import 'package:awesome_dialog/awesome_dialog.dart';
 import 'package:flutter/material.dart';
 
-import 'routes.dart';
-
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
@@ -11,11 +9,10 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Fancy Dialog Example',
-      theme: ThemeData.dark(),
-      initialRoute: '/',
-      onGenerateRoute: RouteGenerator.generateRoute,
-    );
+        title: 'Fancy Dialog Example',
+        theme: ThemeData.dark(),
+        initialRoute: '/',
+        home: HomePage());
   }
 }
 


### PR DESCRIPTION
A teacher just tested the code in front of his students. 

We thought it was just copy and paste from the pub.dev website but as it turns out there's an unrelated import called 'routes.dart' which wasted quite a bit of time to remove. This was the final modification, hopefully to avoid future embarassments.