### PR TITLE
Custom dialog elevation feature

### DIFF
--- a/lib/awesome_dialog.dart
+++ b/lib/awesome_dialog.dart
@@ -50,6 +50,7 @@ class AwesomeDialog {
       this.showCloseIcon = false,
       this.closeIcon,
       this.dialogBackgroundColor,
+      this.dialogElevation = 0.5,
       this.borderSide,
       this.buttonsTextStyle,
       this.autoDismiss = true,
@@ -175,6 +176,12 @@ class AwesomeDialog {
   /// Custom background color for dialog + header
   final Color? dialogBackgroundColor;
 
+  /// Elevation of dialog + header
+  /// 
+  /// Defaults to `0.5`
+
+  final double dialogElevation;
+
   /// Set BorderSide of DialogShape
   final BorderSide? borderSide;
 
@@ -279,6 +286,7 @@ class AwesomeDialog {
         child: _getDialogWidget(
           child: VerticalStackDialog(
             dialogBackgroundColor: dialogBackgroundColor,
+            dialogElevation: dialogElevation,
             borderSide: borderSide,
             borderRadius: dialogBorderRadius,
             header: _buildHeader,

--- a/lib/src/vertical_stack_header_dialog.dart
+++ b/lib/src/vertical_stack_header_dialog.dart
@@ -23,6 +23,7 @@ class VerticalStackDialog extends StatelessWidget {
     required this.onClose,
     this.closeIcon,
     this.dialogBackgroundColor,
+    this.dialogElevation = 0.5,
     this.borderSide,
     this.borderRadius,
     this.bodyHeaderDistance = 15.0,
@@ -45,6 +46,7 @@ class VerticalStackDialog extends StatelessWidget {
   final void Function() onClose;
   final Widget? closeIcon;
   final Color? dialogBackgroundColor;
+  final double dialogElevation;
   final BorderSide? borderSide;
   final BorderRadiusGeometry? borderRadius;
   final double bodyHeaderDistance;
@@ -75,7 +77,7 @@ class VerticalStackDialog extends StatelessWidget {
                     ),
                 side: borderSide ?? BorderSide.none,
               ),
-              elevation: 0.5,
+              elevation: dialogElevation,
               color: dialogBackgroundColor ?? theme.cardColor,
               child: Padding(
                 padding: padding,


### PR DESCRIPTION
Hi!

Thank you for a nice library!

I've noticed that if I use `dialogBackgroundColor: Colors.transparent`, the dialog is dropping a shade coming from its `elevation: 0.5` property:
![Screenshot from 2023-02-23 21-42-35](https://user-images.githubusercontent.com/20026712/221016935-d37807fb-ad19-4e28-a33e-911c84eceb0f.png)

I propose to make this property customizable, so that it could be set 0 resulting in no shade:
![Screenshot from 2023-02-23 21-55-08](https://user-images.githubusercontent.com/20026712/221017285-90ffa547-2c49-4507-bac6-adfb7881d8ed.png)
